### PR TITLE
MCP documentation: Add reference to medium-sized `llms.txt` file

### DIFF
--- a/cratedb_mcp/__main__.py
+++ b/cratedb_mcp/__main__.py
@@ -4,7 +4,7 @@ import httpx
 
 from mcp.server.fastmcp import FastMCP
 
-from .constants import Queries
+from .constants import Queries, DOCUMENTATION_INDEX
 
 mcp = FastMCP("cratedb-mcp")
 
@@ -23,16 +23,7 @@ def query_sql(query: str):
 @mcp.tool(description='Gets an index with CrateDB documentation links to fetch, should download docs'
                       ' before answering questions. Has documentation name, description and link.')
 def get_cratedb_documentation_index():
-    doc_index = [
-        {"name": "scalar functions",
-         "description": "documentation about specific scalar/methods/functions for CrateDB SQL",
-         "link": "https://raw.githubusercontent.com/crate/crate/refs/heads/5.10/docs/general/builtins/scalar-functions.rst"},
-        {"name": "optimize query 101",
-         "description": "documentation about optimizing CrateDB SQL statements",
-         "link": "https://raw.githubusercontent.com/crate/cratedb-guide/9ab661997d7704ecbb63af9c3ee33535957e24e6/docs/performance/optimization.rst"
-         }
-    ]
-    return doc_index
+    return DOCUMENTATION_INDEX
 
 @mcp.tool(description='Downloads the latest CrateDB documentation piece by link.'
                       ' Only used to download CrateDB docs.')

--- a/cratedb_mcp/constants.py
+++ b/cratedb_mcp/constants.py
@@ -85,6 +85,10 @@ WITH partitions_health AS (SELECT table_name,
 DOCUMENTATION_INDEX = [
     # TODO: Add all there are.
     {
+        "name": "about/overview",
+        "description": "The most important factual and technical information about CrateDB per medium-sized (~300kB) llms.txt context file.",
+        "link": "https://cdn.crate.io/about/v1/llms.txt"},
+    {
         "name": "scalar functions",
         "description": "documentation about specific scalar/methods/functions for CrateDB SQL",
         "link": "https://raw.githubusercontent.com/crate/crate/refs/heads/5.10/docs/general/builtins/scalar-functions.rst"},


### PR DESCRIPTION
## About
After publishing the generated resources adhering to the https://llmstxt.org/ convention to https://cdn.crate.io/about/v1/, we can use/pull it from there.

## References
- https://github.com/crate/about/issues/5

## Trivia

You can use those [example questions](https://github.com/crate/about/blob/6aae2ad4d92150bbcf6cb78b941a514fbc29505a/src/cratedb_about/model.py#L12-L31) as an inspiration to ask the machine about details of CrateDB it otherwise wouldn't know easily.
