### PR TITLE
MCP docs: Use resource index from `cratedb-about`

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -60,7 +60,7 @@ jobs:
           # `uv publish` does not understand `--skip-existing`.
           # https://github.com/astral-sh/uv/issues/7917
           # https://github.com/astral-sh/uv/issues/12369
-          uvx twine upload --non-interactive --repository-url https://test.pypi.org/legacy/ --skip-existing dist/*
+          uvx twine upload --non-interactive --verbose --repository-url https://test.pypi.org/legacy/ --skip-existing dist/*
 
       - name: Publish package to PyPI
         if: startsWith(github.event.ref, 'refs/tags')

--- a/cratedb_mcp/settings.py
+++ b/cratedb_mcp/settings.py
@@ -12,3 +12,6 @@ except ValueError as e:  # pragma: no cover
     # TODO: Add software test after refactoring away from module scope.
     warnings.warn(f"Environment variable `CRATEDB_MCP_DOCS_CACHE_TTL` invalid: {e}. "
                   f"Using default value: {DOCS_CACHE_TTL}.", category=UserWarning, stacklevel=2)
+
+# Configure HTTP timeout for all conversations.
+HTTP_TIMEOUT = 10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "cratedb-about==0.0.3",
+  "cachetools<6",
+  "cratedb-about==0.0.4",
   "hishel<0.2",
   "mcp[cli]>=1.5.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
+  "cratedb-about==0.0.3",
   "hishel<0.2",
   "mcp[cli]>=1.5.0",
 ]

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1,10 +1,14 @@
-from cratedb_mcp.knowledge import DOCUMENTATION_INDEX, Queries
+from cratedb_mcp.knowledge import DocumentationIndex, Queries
 
 
 def test_documentation_index():
-    assert len(DOCUMENTATION_INDEX) == 3
-    assert DOCUMENTATION_INDEX[1]["name"] == "scalar functions"
-    assert DOCUMENTATION_INDEX[2]["name"] == "optimize query 101"
+    documentation_index = DocumentationIndex()
+    titles = [item["title"] for item in documentation_index.items()]
+    assert len(titles) >= 50
+    assert "CrateDB database" in titles
+    assert "CrateDB features" in titles
+    assert "CrateDB SQL reference: Scalar functions" in titles
+    assert "Guide: CrateDB query optimization" in titles
 
 
 def test_queries():

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -15,12 +15,17 @@ def test_get_documentation_index():
 
 def test_fetch_docs_forbidden():
     with pytest.raises(ValueError) as ex:
-        fetch_cratedb_docs("https://cratedb.com/docs/crate/reference/en/latest/_sources/general/builtins/scalar-functions.rst.txt")
-    assert ex.match("Only github cratedb links can be fetched")
+        fetch_cratedb_docs("https://example.com")
+    assert ex.match("Link is not permitted: https://example.com")
 
 
-def test_fetch_docs_permitted():
+def test_fetch_docs_permitted_github():
     response = fetch_cratedb_docs("https://raw.githubusercontent.com/crate/crate/refs/heads/5.10/docs/general/builtins/scalar-functions.rst")
+    assert "initcap" in response
+
+
+def test_fetch_docs_permitted_cratedb_com():
+    response = fetch_cratedb_docs("https://cratedb.com/docs/crate/reference/en/latest/_sources/general/builtins/scalar-functions.rst.txt")
     assert "initcap" in response
 
 


### PR DESCRIPTION
## About
The [cratedb-about](https://pypi.org/project/cratedb-about/) package now includes a knowledge outline file in YAML format, [cratedb-outline.yaml], and also provides a compact Python API `cratedb_about.CrateDbKnowledgeOutline` to read and query it. [^1] /cc @WalBeh 

## Details
As far as we can foresee it, it can populate the existing `DOCUMENTATION_INDEX` with a few more curated resources, which could possibly level up knowledge in question answering.
```python
# Load knowledge outline from YAML file and read all items.
outline = CrateDbKnowledgeOutline.load()
DOCUMENTATION_INDEX = outline.find_items().to_dict()
```

## Notes
> [!NOTE]
> That's a stacked PR. GH-9 will need to go in first.

> [!NOTE]
> This change has not been tested. Can you try it before or after merging, to be confident it works reasonably in practice?

[^1]: If you like the idea, [cratedb-outline.yaml] is the right spot to propose any changes going forward, serving as a single source of truth for a curated knowledge outline. Because we picked up that the `description` attribute is very important as it will guide LLMs to the right resources, any contributions to improve the status quo are very much welcome.

[cratedb-outline.yaml]: https://github.com/crate/about/blob/v0.0.3/src/cratedb_about/outline/cratedb-outline.yaml
