### PR TITLE
MCP docs: Use Hishel for transparently caching responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ local_settings.py
 db.sqlite3
 db.sqlite3-journal
 
+# Databases:
+*.sqlite
+
 # Flask stuff:
 instance/
 .webassets-cache

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
 - Packaging: Adjusted package dependencies for interoperability
 - Packaging: Added basic CLI entry point and server launcher `cratedb-mcp`
 - Documentation: Show a simple Claude Desktop configuration
-- MCP documentation: Add reference to medium-sized llms.txt context file
+- MCP docs: Add reference to medium-sized llms.txt context file
 - Boilerplate: Added software tests and CI configuration
 - Documentation: Added development sandbox section
+- MCP docs: Used Hishel for transparently caching documentation resources,
+  by default for one hour. Use the `CRATEDB_MCP_DOCS_CACHE_TTL` environment
+  variable to adjust (default: 3600)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ export CRATEDB_MCP_HTTP_URL="http://localhost:4200/"
 export CRATEDB_MCP_HTTP_URL="https://example.aks1.westeurope.azure.cratedb.net:4200"
 ```
 
+The `CRATEDB_MCP_DOCS_CACHE_TTL` environment variable (default: 3600) defines
+the cache lifetime for documentation resources.
+
 # Usage
 Start MCP server with `stdio` transport (default).
 ```shell

--- a/cratedb_mcp/settings.py
+++ b/cratedb_mcp/settings.py
@@ -1,3 +1,14 @@
 import os
+import warnings
 
 HTTP_URL: str = os.getenv("CRATEDB_MCP_HTTP_URL", "http://localhost:4200")
+
+# Configure cache lifetime for documentation resources.
+DOCS_CACHE_TTL: int = 3600
+try:
+    DOCS_CACHE_TTL = int(os.getenv("CRATEDB_MCP_DOCS_CACHE_TTL", DOCS_CACHE_TTL))
+except ValueError as e:  # pragma: no cover
+    # If the environment variable is not a valid integer, use the default value, but warn about it.
+    # TODO: Add software test after refactoring away from module scope.
+    warnings.warn(f"Environment variable `CRATEDB_MCP_DOCS_CACHE_TTL` invalid: {e}. "
+                  f"Using default value: {DOCS_CACHE_TTL}.", category=UserWarning, stacklevel=2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
+  "hishel<0.2",
   "mcp[cli]>=1.5.0",
 ]
 optional-dependencies.develop = [


### PR DESCRIPTION
## About

When accessing documentation resources through HTTP, they don't need to be fetched over and over again, as they will not change that often. A cache TTL of one hour keeps a good balance between saving resources, and resource freshness. wdyt?


## Review

> [!NOTE]
> That's a stacked PR. GH-9 will need to go in first.
