### PR TITLE
CLI: Add option `--version` to report the installed package version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,3 +15,4 @@
   by default for one hour. Use the `CRATEDB_MCP_DOCS_CACHE_TTL` environment
   variable to adjust (default: 3600)
 - SQL: Stronger read-only mode, using `sqlparse`
+- CLI: Added option `--version` to report the installed package version

--- a/cratedb_mcp/__init__.py
+++ b/cratedb_mcp/__init__.py
@@ -1,0 +1,8 @@
+from importlib.metadata import PackageNotFoundError, version
+
+__appname__ = "cratedb-mcp"
+
+try:
+    __version__ = version(__appname__)
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"

--- a/cratedb_mcp/cli.py
+++ b/cratedb_mcp/cli.py
@@ -1,13 +1,19 @@
 import logging
 import os
+import sys
 import typing as t
 
+from cratedb_mcp import __appname__, __version__
 from cratedb_mcp.__main__ import mcp
 
 logger = logging.getLogger(__name__)
 
 
 def main():
+    if "--version" in sys.argv:
+        output = f"{__appname__} {__version__}"
+        print(output)  # noqa: T201
+        return
     transport = os.getenv("CRATEDB_MCP_TRANSPORT", "stdio")
     if transport not in ("stdio", "sse"):
         raise ValueError(f"Unsupported transport: '{transport}'. Please use one of 'stdio', 'sse'.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+import pytest
+from mcp.server import FastMCP
+
+from cratedb_mcp import __appname__, __version__
+from cratedb_mcp.cli import main
+
+
+def test_cli_version(mocker, capsys):
+    """
+    Verify `cratedb-mcp --version` works as expected.
+    """
+    mocker.patch.object(sys, "argv", ["cratedb-mcp", "--version"])
+    main()
+    out, err = capsys.readouterr()
+    assert __appname__ in out
+    assert __version__ in out
+
+
+def test_cli_default(mocker, capsys):
+    """
+    Verify `cratedb-mcp` works as expected.
+    """
+    mocker.patch.object(sys, "argv", ["cratedb-mcp"])
+    run_mock = mocker.patch.object(FastMCP, "run")
+    main()
+    assert run_mock.call_count == 1
+
+
+def test_cli_invalid_transport(mocker, capsys):
+    """
+    Verify `cratedb-mcp` fails when an invalid transport is specified.
+    """
+    mocker.patch.object(sys, "argv", ["cratedb-mcp"])
+    mocker.patch.dict(os.environ, {"CRATEDB_MCP_TRANSPORT": "foo"})
+    with pytest.raises(ValueError) as excinfo:
+        main()
+    assert excinfo.match("Unsupported transport: 'foo'. Please use one of 'stdio', 'sse'.")


### PR DESCRIPTION
`cratedb-mcp --version` was missing yet. It can make a positive difference to have it, especially in troubleshooting situations.