### PR TITLE
Options: Rename `CRATEDB_MCP_HTTP_URL` to `CRATEDB_CLUSTER_URL`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # CrateDB MCP changelog
 
 ## Unreleased
+- Options: Renamed `CRATEDB_MCP_HTTP_URL` to `CRATEDB_CLUSTER_URL`,
+  standardizing on common naming conventions
 
 ## v0.0.0 - 2025-05-16
 - Project: Established project layout

--- a/README.md
+++ b/README.md
@@ -91,15 +91,15 @@ Notes:
 
 ## Configure
 
-Configure the `CRATEDB_MCP_HTTP_URL` environment variable to match your CrateDB instance.
+Configure the `CRATEDB_CLUSTER_URL` environment variable to match your CrateDB instance.
 For example, when connecting to CrateDB Cloud, use a value like
 `https://admin:dZ...6LqB@testdrive.eks1.eu-west-1.aws.cratedb.net:4200/`.
 When connecting to CrateDB on localhost, use `http://localhost:4200/`.
 ```shell
-export CRATEDB_MCP_HTTP_URL="https://example.aks1.westeurope.azure.cratedb.net:4200"
+export CRATEDB_CLUSTER_URL="https://example.aks1.westeurope.azure.cratedb.net:4200"
 ```
 ```shell
-export CRATEDB_MCP_HTTP_URL="http://localhost:4200/"
+export CRATEDB_CLUSTER_URL="http://localhost:4200/"
 ```
 
 The `CRATEDB_MCP_HTTP_TIMEOUT` environment variable (default: 30.0) defines
@@ -129,7 +129,7 @@ To use the MCP version within Claude Desktop, you can use the following configur
       "command": "uvx",
       "args": ["cratedb-mcp"],
       "env": {
-        "CRATEDB_MCP_HTTP_URL": "http://localhost:4200/",
+        "CRATEDB_CLUSTER_URL": "http://localhost:4200/",
         "CRATEDB_MCP_TRANSPORT": "stdio"
       }
     }

--- a/cratedb_mcp/settings.py
+++ b/cratedb_mcp/settings.py
@@ -3,7 +3,7 @@ import warnings
 
 from attr.converters import to_bool
 
-HTTP_URL: str = os.getenv("CRATEDB_MCP_HTTP_URL", "http://localhost:4200")
+HTTP_URL: str = os.getenv("CRATEDB_CLUSTER_URL", "http://localhost:4200")
 
 
 class Settings:


### PR DESCRIPTION
## About
CrateDB Toolkit started to standardize on common naming conventions. In this case, its Cluster API and many subsystems it supports now understand the `CRATEDB_CLUSTER_URL` environment variable. This patch also uses the same name here.

- https://cratedb-toolkit.readthedocs.io/cluster/cli.html#configure
