### PR TITLE
CLI: Add subcommand `cratedb-mcp serve` using Click

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## Unreleased
 - Options: Renamed `CRATEDB_MCP_HTTP_URL` to `CRATEDB_CLUSTER_URL`,
   standardizing on common naming conventions
+- CLI: Added subcommand `cratedb-mcp serve` using Click, with
+  dedicated options `--transport` and `--port`
 
 ## v0.0.0 - 2025-05-16
 - Project: Established project layout

--- a/README.md
+++ b/README.md
@@ -112,12 +112,18 @@ the cache lifetime for documentation resources in seconds.
 ## Usage
 Start MCP server with `stdio` transport (default).
 ```shell
-CRATEDB_MCP_TRANSPORT=stdio cratedb-mcp
+cratedb-mcp serve --transport=stdio
 ```
 Start MCP server with `sse` transport.
 ```shell
-CRATEDB_MCP_TRANSPORT=sse cratedb-mcp
+cratedb-mcp serve --transport=sse
 ```
+Start MCP server with `streamable-http` transport.
+```shell
+cratedb-mcp serve --transport=streamable-http
+```
+Alternatively, use the `CRATEDB_MCP_TRANSPORT` environment variable instead of
+the `--transport` option.
 
 ### Anthropic Claude
 To use the MCP version within Claude Desktop, you can use the following configuration:
@@ -127,7 +133,7 @@ To use the MCP version within Claude Desktop, you can use the following configur
   "mcpServers": {
     "my_cratedb": {
       "command": "uvx",
-      "args": ["cratedb-mcp"],
+      "args": ["cratedb-mcp", "serve"],
       "env": {
         "CRATEDB_CLUSTER_URL": "http://localhost:4200/",
         "CRATEDB_MCP_TRANSPORT": "stdio"
@@ -151,23 +157,23 @@ brew install mcp uv
 
 Explore the Text-to-SQL API.
 ```shell
-mcpt call query_sql --params '{"query":"SELECT * FROM sys.summits LIMIT 3"}' uvx cratedb-mcp
+mcpt call query_sql --params '{"query":"SELECT * FROM sys.summits LIMIT 3"}' uvx cratedb-mcp serve
 ```
 ```shell
-mcpt call get_table_metadata uvx cratedb-mcp
+mcpt call get_table_metadata uvx cratedb-mcp serve
 ```
 ```shell
-mcpt call get_health uvx cratedb-mcp
+mcpt call get_health uvx cratedb-mcp serve
 ```
 
 Exercise the documentation server API.
 ```shell
-mcpt call get_cratedb_documentation_index uvx cratedb-mcp
+mcpt call get_cratedb_documentation_index uvx cratedb-mcp serve
 ```
 ```shell
 mcpt call \
   fetch_cratedb_docs --params '{"link":"https://cratedb.com/docs/cloud/en/latest/_sources/cluster/integrations/mongo-cdc.md.txt"}' \
-  uvx cratedb-mcp
+  uvx cratedb-mcp serve
 ```
 
 ## Development

--- a/cratedb_mcp/__main__.py
+++ b/cratedb_mcp/__main__.py
@@ -1,6 +1,7 @@
 import httpx
 from mcp.server.fastmcp import FastMCP
 
+from . import __appname__
 from .knowledge import DocumentationIndex, Queries
 from .settings import HTTP_URL, Settings
 from .util.sql import sql_is_permitted
@@ -9,7 +10,7 @@ from .util.sql import sql_is_permitted
 documentation_index = DocumentationIndex()
 
 # Create FastMCP application object.
-mcp = FastMCP("cratedb-mcp")
+mcp = FastMCP(__appname__)
 
 
 def query_cratedb(query: str) -> list[dict]:

--- a/cratedb_mcp/cli.py
+++ b/cratedb_mcp/cli.py
@@ -1,21 +1,50 @@
 import logging
-import os
-import sys
 import typing as t
 
-from cratedb_mcp import __appname__, __version__
+import click
+from pueblo.util.cli import boot_click
+
 from cratedb_mcp.__main__ import mcp
 
 logger = logging.getLogger(__name__)
 
 
-def main():
-    if "--version" in sys.argv:
-        output = f"{__appname__} {__version__}"
-        print(output)  # noqa: T201
-        return
-    transport = os.getenv("CRATEDB_MCP_TRANSPORT", "stdio")
-    if transport not in ("stdio", "sse"):
-        raise ValueError(f"Unsupported transport: '{transport}'. Please use one of 'stdio', 'sse'.")
-    logger.info(f"Starting CrateDB MCP server using transport '{transport}'")
-    mcp.run(transport=t.cast(t.Literal["stdio", "sse"], transport))
+@click.group()
+@click.version_option()
+@click.pass_context
+def cli(ctx: click.Context) -> None:
+    """
+    CrateDB MCP server.
+
+    Documentation: https://github.com/crate/cratedb-mcp
+    """
+    boot_click(ctx=ctx)
+
+
+transport_types = t.Literal["stdio", "sse", "streamable-http"]
+transport_choices = t.get_args(transport_types)
+
+
+@cli.command()
+@click.option(
+    "--transport",
+    envvar="CRATEDB_MCP_TRANSPORT",
+    type=click.Choice(transport_choices),
+    default="stdio",
+    help="The transport protocol (stdio, sse, streamable-http)",
+)
+@click.option(
+    "--port",
+    envvar="CRATEDB_MCP_PORT",
+    type=int,
+    default=8000,
+    help="The port to listen on (for sse and streamable-http)",
+)
+@click.pass_context
+def serve(ctx: click.Context, transport: str, port: int) -> None:
+    """
+    Start MCP server.
+    """
+    logger.info(f"CrateDB MCP server starting with transport: {transport}")
+    mcp.settings.port = port
+    mcp.run(transport=t.cast(transport_types, transport))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,11 @@ dynamic = [
 dependencies = [
   "attrs",
   "cachetools<6",
+  "click<9",
   "cratedb-about==0.0.4",
   "hishel<0.2",
   "mcp[cli]>=1.5.0",
+  "pueblo==0.0.11",
   "sqlparse<0.6",
 ]
 optional-dependencies.develop = [
@@ -90,7 +92,7 @@ optional-dependencies.test = [
   "pytest-mock<4",
 ]
 
-scripts.cratedb-mcp = "cratedb_mcp.cli:main"
+scripts.cratedb-mcp = "cratedb_mcp.cli:cli"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## About
[Explicit is better than implicit](https://peps.python.org/pep-0020/): Following common sense, and [excellent blueprints of others](https://fluxcd.control-plane.io/mcp/config/), this patch adds command-line parsing using a standard interface, to improve discoverability of subcommands and options for both humans and machines.

## Details
- `cratedb-mcp serve` now provides dedicated options `--transport` and `--port`.
- The MCP server now also supports the new `streamable-http` transport.
  > The [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) transport from protocol version 2025-03-26 is the recommended transport mechanism for web-based MCP applications, replacing the [HTTP+SSE transport](https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse) from protocol version 2024-11-05.
