### PR TITLE
README: Add recommendations to use a read-only database user

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
   introducing powerful client capabilities, server proxying & composition,
   OpenAPI/FastAPI integration, and more advanced features.
   See [FastMCP 2.0 and the Official MCP SDK].
+- README: Added recommendations to use a read-only database user
+  to prevent agents from modifying the database content
 
 [FastMCP 2.0 and the Official MCP SDK]: https://gofastmcp.com/getting-started/welcome#fastmcp-2-0-and-the-official-mcp-sdk
 

--- a/README.md
+++ b/README.md
@@ -181,16 +181,6 @@ Relevant information is pulled from <https://cratedb.com/docs>, curated per
 <br>
 Tool names are: `get_cratedb_documentation_index`, `fetch_cratedb_docs`
 
-### Security considerations
-
-**By default, the application will access the database in read-only mode.**
-
-We do not recommend letting LLM-based agents insert or modify data by itself.
-As such, only `SELECT` statements are permitted and forwarded to the database.
-All other operations will raise a `ValueError` exception, unless the
-`CRATEDB_MCP_PERMIT_ALL_STATEMENTS` environment variable is set to a
-truthy value. This is **not** recommended.
-
 ### Install
 
 The configuration snippets for AI assistants are using the `uvx` launcher
@@ -232,6 +222,23 @@ in seconds.
 
 The `CRATEDB_MCP_DOCS_CACHE_TTL` environment variable (default: 3600) defines
 the cache lifetime for documentation resources in seconds.
+
+### Security considerations
+
+If you want to prevent agents from modifying data, i.e., permit `SELECT` statements
+only, it is recommended to [create a read-only database user by using "GRANT DQL"].
+```sql
+CREATE USER "read-only" WITH (password = 'YOUR_PASSWORD');
+GRANT DQL TO "read-only";
+```
+Then, include relevant access credentials in the cluster URL.
+```shell
+export CRATEDB_CLUSTER_URL="https://read-only:YOUR_PASSWORD@example.aks1.westeurope.azure.cratedb.net:4200"
+```
+The MCP Server also prohibits non-SELECT statements on the application level.
+All other operations will raise a `PermissionError` exception, unless the
+`CRATEDB_MCP_PERMIT_ALL_STATEMENTS` environment variable is set to a
+truthy value.
 
 ### Operate
 
@@ -289,6 +296,7 @@ Version pinning is strongly recommended, especially if you use it as a library.
 [CrateDB]: https://cratedb.com/database
 [cratedb-about]: https://pypi.org/project/cratedb-about/
 [cratedb-outline.yaml]: https://github.com/crate/about/blob/v0.0.4/src/cratedb_about/outline/cratedb-outline.yaml
+[create a read-only database user by using "GRANT DQL"]: https://community.cratedb.com/t/create-read-only-database-user-by-using-grant-dql/2031
 [development documentation]: https://github.com/crate/cratedb-mcp/blob/main/DEVELOP.md
 [example questions]: https://github.com/crate/about/blob/v0.0.4/src/cratedb_about/query/model.py#L17-L44
 [examples folder]: https://github.com/crate/cratedb-mcp/tree/main/examples

--- a/cratedb_mcp/__main__.py
+++ b/cratedb_mcp/__main__.py
@@ -27,7 +27,7 @@ def query_cratedb(query: str) -> list[dict]:
 )
 def query_sql(query: str):
     if not sql_is_permitted(query):
-        raise ValueError("Only queries that have a SELECT statement are allowed.")
+        raise PermissionError("Only queries that have a SELECT statement are allowed.")
     return query_cratedb(query)
 
 

--- a/examples/mcptools.sh
+++ b/examples/mcptools.sh
@@ -14,8 +14,17 @@ set -euo pipefail
 # brew tap f/mcptools
 # brew install mcp uv
 
+if ! command -v mcptools >/dev/null 2>&1; then
+  echo mcptools not installed, skipping.
+  echo "Skipped."
+  exit 0
+fi
+
 # Some systems do not provide the `mcpt` alias.
 alias mcpt=mcptools
+
+# Display available MCP tools.
+mcpt tools uvx cratedb-mcp serve
 
 # Explore the Text-to-SQL tools.
 mcpt call query_sql --params '{"query":"SELECT * FROM sys.summits LIMIT 3"}' uvx cratedb-mcp serve

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,12 +1,12 @@
 # ruff: noqa: S603, S607
 import subprocess
-from shutil import which
 
 import pytest
 
 
-@pytest.mark.skipif(not which("mcptools"), reason="requires mcptools")
 def test_mcptools():
     proc = subprocess.run(["examples/mcptools.sh"], capture_output=True, timeout=15, check=True)
     assert proc.returncode == 0
+    if b"Skipped." in proc.stdout:
+        raise pytest.skip("mcptools not installed")
     assert b"Ready." in proc.stdout

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -38,7 +38,7 @@ def test_query_sql_permitted():
 
 
 def test_query_sql_forbidden_easy():
-    with pytest.raises(ValueError) as ex:
+    with pytest.raises(PermissionError) as ex:
         assert "RelationUnknown" in str(
             query_sql("INSERT INTO foobar (id) VALUES (42) RETURNING id")
         )
@@ -46,7 +46,7 @@ def test_query_sql_forbidden_easy():
 
 
 def test_query_sql_forbidden_sneak_value():
-    with pytest.raises(ValueError) as ex:
+    with pytest.raises(PermissionError) as ex:
         query_sql("INSERT INTO foobar (operation) VALUES ('select')")
     assert ex.match("Only queries that have a SELECT statement are allowed")
 


### PR DESCRIPTION
## About
Users may want to prevent agents from modifying the database content.
This patch improves the corresponding section in the README document in this regard.

## Details
- Relocate "Security considerations" section after "Configuration" section.
- Add guidelines about [how to create a read-only database user](https://community.cratedb.com/t/create-read-only-database-user-by-using-grant-dql/2031).

## References
The topic has been discussed here.
- https://github.com/crate/cratedb-mcp/pull/11#issuecomment-2883972263 ff.
- GH-10

/cc @hlcianfagna, @hammerhead, @bmunkholm 