### PR TITLE
Remove trailing '/' if it exists

### DIFF
--- a/cratedb_mcp/__main__.py
+++ b/cratedb_mcp/__main__.py
@@ -14,9 +14,12 @@ mcp: FastMCP = FastMCP(__appname__)
 
 
 def query_cratedb(query: str) -> list[dict]:
-    return httpx.post(
-        f"{HTTP_URL}/_sql", json={"stmt": query}, timeout=Settings.http_timeout()
-    ).json()
+    """Sends a `query` to the set `$CRATEDB_CLUSTER_URL`"""
+    url = HTTP_URL
+    if url.endswith("/"):
+        url = url.removesuffix("/")
+
+    return httpx.post(f"{url}/_sql", json={"stmt": query}, timeout=Settings.http_timeout()).json()
 
 
 @mcp.tool(


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
In our docs we recommend setting `"CRATEDB_CLUSTER_URL": "http://localhost:4200/"` but in https://github.com/surister/cratedb-mcp/blob/5c8f404211e33e6a5e9b697fbd728d9f5139a70a/cratedb_mcp/__main__.py#L18 we add an `/`, this small patch fixes it.

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes #30 
