### PR TITLE
Dependencies: Downgrade to `fastmcp<2.7` to fix a breaking change

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # CrateDB MCP changelog
 
 ## Unreleased
+- Dependencies: Downgraded to `fastmcp<2.7` to fix a breaking change
 
 ## v0.0.2 - 2025-05-21
 - Bugfix: Removed trailing `/` on HTTP URL if it exists. Thanks, @surister.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dependencies = [
   "cachetools<7",
   "click<9",
   "cratedb-about==0.0.5",
-  "fastmcp<3",
+  "fastmcp<2.7",
   "hishel<0.2",
   "pueblo==0.0.11",
   "sqlparse<0.6",


### PR DESCRIPTION
What the title says.