### PR TITLE
Transport: Add CLI option `--path`, and improve documentation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Parameters: Added CLI option `--host` and environment variable `CRATEDB_MCP_HOST`
+- Parameters: Added CLI option `--path` and environment variable `CRATEDB_MCP_PATH`
 
 ## v0.0.3 - 2025-06-18
 - Dependencies: Downgraded to `fastmcp<2.7` to fix a breaking change

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ customers should use this feature at their own discretion.
 ### Quickstart Guide
 
 The CrateDB MCP Server is compatible with AI assistants that support the Model
-Context Protocol (MCP), either using standard input/output (stdio),
-server-sent events (SSE), or HTTP Streams (streamable-http).
+Context Protocol (MCP), either using standard input/output (`stdio`),
+server-sent events (`sse`), or HTTP Streams (`http`, earlier `streamable-http`).
 
 To use the MCP server, you need a [client that supports][MCP clients] the
 protocol. The most notable ones are ChatGPT, Claude, Cline Bot, Cursor,
@@ -223,6 +223,31 @@ in seconds.
 The `CRATEDB_MCP_DOCS_CACHE_TTL` environment variable (default: 3600) defines
 the cache lifetime for documentation resources in seconds.
 
+### Configure transport
+
+MCP servers can be started using different transport modes. The default transport
+is `stdio`, you can select another one of `{"stdio", "sse", "http"}`
+and supply it to the invocation like this:
+```shell
+cratedb-mcp serve --transport=stdio
+```
+NB: The `http` transport was called `streamable-http` in earlier spec iterations.
+
+When using one of the HTTP-based options for serving the MCP interface, you can
+use the CLI options `--host`, `--port` and `--path` to specify the listening address.
+The default values are `localhost:8000`, where the SSE server responds to `/sse/`
+and `/messages/` and the HTTP server responds to `/mcp/` by default.
+
+Alternatively, you can use environment variables instead of CLI options.
+```shell
+export CRATEDB_MCP_TRANSPORT=http
+export CRATEDB_MCP_HOST=0.0.0.0
+export CRATEDB_MCP_PORT=8000
+```
+```shell
+export CRATEDB_MCP_PATH=/path/in/url
+```
+
 ### Security considerations
 
 If you want to prevent agents from modifying data, i.e., permit `SELECT` statements
@@ -250,9 +275,9 @@ Start MCP server with `sse` transport.
 ```shell
 cratedb-mcp serve --transport=sse
 ```
-Start MCP server with `streamable-http` transport.
+Start MCP server with `http` transport (ex. `streamable-http`).
 ```shell
-cratedb-mcp serve --transport=streamable-http
+cratedb-mcp serve --transport=http
 ```
 Alternatively, use the `CRATEDB_MCP_TRANSPORT` environment variable instead of
 the `--transport` option.

--- a/cratedb_mcp/cli.py
+++ b/cratedb_mcp/cli.py
@@ -47,12 +47,26 @@ transport_choices = t.get_args(transport_types)
     default=8000,
     help="The port to listen on (for sse and streamable-http)",
 )
+@click.option(
+    "--path",
+    envvar="CRATEDB_MCP_PATH",
+    type=str,
+    required=False,
+    help="The URL path to serve on (for sse, http)",
+)
 @click.pass_context
-def serve(ctx: click.Context, transport: str, host: str, port: int) -> None:
+def serve(
+    ctx: click.Context, transport: str, host: str, port: int, path: t.Optional[str] = None
+) -> None:
     """
     Start MCP server.
     """
     logger.info(f"CrateDB MCP server starting with transport: {transport}")
-    mcp.settings.host = host
-    mcp.settings.port = port
-    mcp.run(transport=t.cast(transport_types, transport))
+    transport_kwargs = {}
+    if transport in {"sse", "http", "streamable-http"}:
+        transport_kwargs = {
+            "host": host,
+            "port": port,
+            "path": path,
+        }
+    mcp.run(transport=t.cast(transport_types, transport), **transport_kwargs)  # type: ignore[arg-type]

--- a/cratedb_mcp/cli.py
+++ b/cratedb_mcp/cli.py
@@ -21,7 +21,7 @@ def cli(ctx: click.Context) -> None:
     boot_click(ctx=ctx)
 
 
-transport_types = t.Literal["stdio", "sse", "streamable-http"]
+transport_types = t.Literal["stdio", "sse", "http", "streamable-http"]
 transport_choices = t.get_args(transport_types)
 
 
@@ -31,21 +31,21 @@ transport_choices = t.get_args(transport_types)
     envvar="CRATEDB_MCP_TRANSPORT",
     type=click.Choice(transport_choices),
     default="stdio",
-    help="The transport protocol (stdio, sse, streamable-http)",
+    help="The transport protocol (stdio, sse, http, ex. streamable-http)",
 )
 @click.option(
     "--host",
     envvar="CRATEDB_MCP_HOST",
     type=str,
     default="127.0.0.1",
-    help="The host to listen on (for sse and streamable-http)",
+    help="The host to listen on (for sse, http)",
 )
 @click.option(
     "--port",
     envvar="CRATEDB_MCP_PORT",
     type=int,
     default=8000,
-    help="The port to listen on (for sse and streamable-http)",
+    help="The port to listen on (for sse, http)",
 )
 @click.option(
     "--path",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,12 +79,11 @@ def test_cli_valid_default(mocker, capsys):
     # Verify the outcome.
     assert run_mock.call_count == 1
     assert run_mock.call_args == mock.call("stdio")
-    assert mcp.settings.port == 8000
 
 
 def test_cli_valid_custom(mocker, capsys):
     """
-    Verify `cratedb-mcp serve --transport=streamable-http --port=65535` works as expected.
+    Verify `cratedb-mcp serve --transport=http --port=65535` works as expected.
 
     The test needs to mock `anyio.run`, otherwise the call would block forever.
     """
@@ -94,14 +93,13 @@ def test_cli_valid_custom(mocker, capsys):
     runner = CliRunner()
     runner.invoke(
         cli,
-        args=["serve", "--transport=streamable-http", "--port=65535"],
+        args=["serve", "--transport=http", "--port=65535"],
         catch_exceptions=False,
     )
 
     # Verify the outcome.
     assert run_mock.call_count == 1
-    assert run_mock.call_args == mock.call("streamable-http")
-    assert mcp.settings.port == 65535
+    assert run_mock.call_args == mock.call("http", host="127.0.0.1", port=65535, path=None)
 
 
 def test_cli_invalid_transport_option(mocker, capsys):


### PR DESCRIPTION
## About

If you want to provide your HTTP endpoint on a different URL path than the defaults `/sse/` or `/mcp/`, using the new `--path` option is way to go. Along the lines, the patch also improves documentation about the transport options in general.