### PR TITLE
MCP: Fix `get_cratedb_documentation_index` tool

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # CrateDB MCP changelog
 
 ## Unreleased
+- MCP: Fixed defunct `get_cratedb_documentation_index` tool
 
 ## v0.0.4 - 2025-07-21
 - Parameters: Added CLI option `--host` and environment variable `CRATEDB_MCP_HOST`

--- a/cratedb_mcp/tool.py
+++ b/cratedb_mcp/tool.py
@@ -40,7 +40,7 @@ def get_table_metadata() -> dict:
 documentation_index = DocumentationIndex()
 
 
-def get_cratedb_documentation_index() -> dict:
+def get_cratedb_documentation_index() -> list:
     """Get curated CrateDB documentation index."""
     return documentation_index.items()
 

--- a/examples/mcptools.sh
+++ b/examples/mcptools.sh
@@ -24,17 +24,17 @@ fi
 alias mcpt=mcptools
 
 # Display available MCP tools.
-mcpt tools uvx cratedb-mcp serve
+mcpt tools cratedb-mcp serve
 
 # Explore the Text-to-SQL tools.
-mcpt call query_sql --params '{"query":"SELECT * FROM sys.summits LIMIT 3"}' uvx cratedb-mcp serve
-mcpt call get_table_metadata uvx cratedb-mcp serve
-mcpt call get_cluster_health uvx cratedb-mcp serve
+mcpt call query_sql --params '{"query":"SELECT * FROM sys.summits LIMIT 3"}' cratedb-mcp serve
+mcpt call get_table_metadata cratedb-mcp serve
+mcpt call get_cluster_health cratedb-mcp serve
 
 # Exercise the documentation server tools.
-mcpt call get_cratedb_documentation_index uvx cratedb-mcp serve
+mcpt call get_cratedb_documentation_index cratedb-mcp serve
 mcpt call \
   fetch_cratedb_docs --params '{"link":"https://cratedb.com/docs/cloud/en/latest/_sources/cluster/integrations/mongo-cdc.md.txt"}' \
-  uvx cratedb-mcp serve
+  cratedb-mcp serve
 
 echo "Ready."


### PR DESCRIPTION
## About

With v0.0.4, the tool `get_cratedb_documentation_index` went south, because of a wrong type annotation.

## References

- GH-58
