### PR TITLE
MCP: Start using MCP tool descriptions from Python docstrings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - OCI: Added `curl` to image
 - MCP: Started using MCP tool descriptions from Python docstrings
+- Instructions: Copy-editing. Wording.
 
 ## v0.0.5 - 2025-07-22
 - MCP: Fixed defunct `get_cratedb_documentation_index` tool

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - OCI: Added `curl` to image
+- MCP: Started using MCP tool descriptions from Python docstrings
 
 ## v0.0.5 - 2025-07-22
 - MCP: Fixed defunct `get_cratedb_documentation_index` tool

--- a/cratedb_mcp/core.py
+++ b/cratedb_mcp/core.py
@@ -41,17 +41,15 @@ class CrateDbMcp:
         # ------------------------------------------
         self.mcp.add_tool(
             Tool.from_function(
-                fn=get_table_metadata,
-                description="Return column schema and metadata for all tables stored in CrateDB. "
-                "Use it to inquire entities you don't know about.",
+                fn=query_sql,
+                description=query_sql.__doc__,
                 tags={"text-to-sql"},
             )
         )
         self.mcp.add_tool(
             Tool.from_function(
-                fn=query_sql,
-                description="Send an SQL query to CrateDB and return results. "
-                "Only 'SELECT' queries are allowed.",
+                fn=get_table_metadata,
+                description=get_table_metadata.__doc__,
                 tags={"text-to-sql"},
             )
         )
@@ -62,16 +60,14 @@ class CrateDbMcp:
         self.mcp.add_tool(
             Tool.from_function(
                 fn=get_cratedb_documentation_index,
-                description="Get an index of CrateDB documentation links for fetching. "
-                "Should download docs before answering questions. "
-                "Has documentation title, description, and link.",
+                description=get_cratedb_documentation_index.__doc__,
                 tags={"documentation"},
             )
         )
         self.mcp.add_tool(
             Tool.from_function(
                 fn=fetch_cratedb_docs,
-                description="Download individual CrateDB documentation pages by link.",
+                description=fetch_cratedb_docs.__doc__,
                 tags={"documentation"},
             )
         )
@@ -82,7 +78,7 @@ class CrateDbMcp:
         self.mcp.add_tool(
             Tool.from_function(
                 fn=get_cluster_health,
-                description="Return the health of the CrateDB cluster.",
+                description=get_cluster_health.__doc__,
                 tags={"health", "monitoring", "status"},
             )
         )

--- a/cratedb_mcp/prompt/instructions.md
+++ b/cratedb_mcp/prompt/instructions.md
@@ -1,25 +1,16 @@
 ## Tool instructions
 
-Use all available tools from the CrateDB MCP server `cratedb-mcp` or derived
-applications for gathering accurate information.
+Use all available tools for gathering accurate information.
 
 You have the following tools available:
-
-1. `get_table_metadata`: Return table and column schema information for all tables stored in CrateDB. Use it when you need to discover entities and database metadata you are unfamiliar with.
-2. `query_sql`: Execute an SQL query on CrateDB and return the results.
+1. `get_table_metadata`: Return table metadata for all tables stored in CrateDB.
+2. `query_sql`: Execute an SQL query on CrateDB and return the results. Select only the columns you need (avoid `SELECT *`) and, where appropriate, add a `LIMIT` clause to keep result sets concise.
 3. `get_cratedb_documentation_index`: Return the table of contents for the curated CrateDB documentation index. Use it whenever you need to verify CrateDB-specific syntax.
-4. `fetch_cratedb_docs`: Given a link returned by `get_cratedb_documentation_index`, fetch the full content of that documentation page.
+4. `fetch_cratedb_docs`: Given a `link` returned by `get_cratedb_documentation_index`, fetch the full content of that documentation page. Content can be quoted verbatim when answering questions about CrateDB.
 
-Those rules are applicable when using the available tools:
- 
-- First use `get_table_metadata` to find out about tables stored in the database and their
-  column names and types. Next, use `query_sql` to execute a parameterised SQL query that
-  returns only the columns you need (avoid `SELECT *`) and, where appropriate, add a
-  `LIMIT` clause to keep result sets concise.
-
-- First use `get_cratedb_documentation_index` to find out about curated documentation resources
-  about CrateDB. Then, use `fetch_cratedb_docs` to retrieve individual pages that
-  can be quoted verbatim when answering questions about CrateDB.
+Please follow those rules when using the available tools:
+- First use `get_table_metadata` to find out about tables stored in the database and their metadata. Next, use `query_sql` to execute the SQL query.
+- First use `get_cratedb_documentation_index` to get an overview about curated documentation resources about CrateDB. Then, use `fetch_cratedb_docs` to retrieve individual pages by `link`.
 
 After fetching data, reason about the output and provide a concise interpretation before
 formulating the final answer.

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -12,10 +12,6 @@ def test_documentation_index():
 
 
 def test_queries():
-    # Verify basic parts of the query.
     assert "information_schema.tables" in Queries.TABLES_METADATA
-
-    # Verify other critical parts of the query.
-    assert "sys.health" in Queries.TABLES_METADATA
-    assert "WITH partitions_health" in Queries.TABLES_METADATA
-    assert "LEFT JOIN" in Queries.TABLES_METADATA
+    assert "partitions_health" in Queries.TABLES_METADATA
+    assert "sys.health" in Queries.HEALTH


### PR DESCRIPTION
Pull MCP tool's `desctription` from Python docstrings. Improve `instructions.md`.