### PR TITLE
OCI: Add `curl` to image

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # CrateDB MCP changelog
 
 ## Unreleased
+- OCI: Added `curl` to image
 
 ## v0.0.5 - 2025-07-22
 - MCP: Fixed defunct `get_cratedb_documentation_index` tool

--- a/release/oci/Dockerfile
+++ b/release/oci/Dockerfile
@@ -25,6 +25,11 @@ FROM python:3.13-slim-bookworm AS standard
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TERM=linux
 
+RUN set -e \
+    && apt-get update \
+    && apt-get --yes install --no-install-recommends --no-install-suggests curl \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install and configure `uv`.
 # Guidelines that have been followed.
 # - https://hynek.me/articles/docker-uv/


### PR DESCRIPTION
## Problem
We found `curl` to be missing for doing container health checks.

## References
- https://github.com/crate/cratedb-examples/pull/1038#discussion_r2224885911