### PR TITLE
Tame logging of HTTPX to not reveal credentials

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # CrateDB MCP changelog
 
 ## Unreleased
+- Tamed logging of HTTPX to not reveal credentials. Thanks, @WalBeh.
 
 ## v0.0.8 - 2025-10-14
 - Rebuild for Debian CVEs

--- a/cratedb_mcp/cli.py
+++ b/cratedb_mcp/cli.py
@@ -19,6 +19,12 @@ def cli(ctx: click.Context) -> None:
 
     Documentation: https://github.com/crate/cratedb-mcp
     """
+
+    # Tame logging of HTTPX to not reveal credentials.
+    # https://github.com/encode/httpx/pull/3513#issuecomment-3360536080
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
+    # Set up logger.
     boot_click(ctx=ctx)
 
 


### PR DESCRIPTION
## About
> The httpx library emits sensitive information to the application log.

## Recommendation
The recommendation is to alter the log level of HTTPX? Well, let's do it then, until swapping it for another library?
- https://github.com/encode/httpx/pull/3513#issuecomment-3360536080

## References
- GH-63


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced logging security by configuring the HTTPX logger to hide sensitive credentials and prevent their exposure in application logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->