### PR TITLE
Dependencies: Stop version-pinning `pueblo` package

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - OCI: Updated to Python 3.14 and Debian 13 "trixie"
+- Dependencies: Stopped version-pinning `pueblo` package
 
 ## v0.1.0 - 2026-03-03
 - Dependencies: Updated to FastMCP 3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
   "cratedb-about<0.1.0",
   "fastmcp>=2.13,<3.2",
   "hishel<0.2",
-  "pueblo==0.0.15",
+  "pueblo>=0.0.15,<0.1",
   "sqlparse<0.6",
 ]
 optional-dependencies.develop = [


### PR DESCRIPTION
## About
Avoid package conflicts when installing dev- or rc-releases of `pueblo`.

## References
- https://github.com/crate/cratedb-examples/pull/1489