### PR TITLE
Security: Fix HIGH/CRITICAL CVEs in fastmcp and OpenSSL (v0.1.2)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v0.1.2 - 2026-05-12
+- Security: Updated to `fastmcp>=3.2`, fixing CVE-2026-32871 (CRITICAL, SSRF via path traversal)
+  and CVE-2026-27124 (HIGH, OAuth consent bypass)
+- Security: OCI image now runs `apt-get upgrade` at build time to apply available Debian patches,
+  fixing CVE-2026-31789 (CRITICAL) in OpenSSL
+
 ## v0.1.1 - 2026-03-22
 - OCI: Updated to Python 3.14 and Debian 13 "trixie"
 - Dependencies: Stopped version-pinning `pueblo` package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
   "cachetools<8",
   "click<9",
   "cratedb-about<0.1.0",
-  "fastmcp>=3.2,<4",
+  "fastmcp>=3.2,<3.3",
   "hishel<0.2",
   "pueblo>=0.0.15,<0.1",
   "sqlparse<0.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
   "cachetools<8",
   "click<9",
   "cratedb-about<0.1.0",
-  "fastmcp>=2.13,<3.2",
+  "fastmcp>=3.2,<4",
   "hishel<0.2",
   "pueblo>=0.0.15,<0.1",
   "sqlparse<0.6",

--- a/release/oci/Dockerfile
+++ b/release/oci/Dockerfile
@@ -43,9 +43,11 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 
 # Install curl, it is needed for health checks.
+# apt-get upgrade ensures security patches from Debian are applied at build time.
 RUN \
     true \
     && apt-get update \
+    && apt-get upgrade --no-install-recommends --yes \
     && apt-get install --no-install-recommends --no-install-suggests --yes curl \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Context

Trivy scan of `ghcr.io/crate/cratedb-mcp:latest` reported 3 CRITICAL and several HIGH CVEs that have fixes available. This PR resolves them with minimal, targeted changes.

## Changes

### 1. Update fastmcp constraint (`pyproject.toml`)

`fastmcp>=2.13,<3.2` → `fastmcp>=3.2,<4`

fastmcp 3.1.x contains two fixed vulnerabilities:

| CVE | Severity | Description |
|-----|----------|-------------|
| CVE-2026-32871 | **CRITICAL** | SSRF via path traversal in OpenAPI path proxy |
| CVE-2026-27124 | **HIGH** | Unauthorized actions via improper OAuth consent validation |

fastmcp 3.2 is a purely additive release (`FastMCPApp` for interactive UIs). The APIs used by this project (`FastMCP`, `Tool.from_function`, `mcp.add_tool`) are unchanged.

Updating fastmcp also pulls in fresh transitive deps, which resolves:
- CVE-2026-42561 (HIGH) in `python-multipart` (fixed in 0.0.27)
- CVE-2026-44431/44432 (HIGH) in `urllib3` (fixed in 2.7.0)

### 2. Add `apt-get upgrade` to OCI runtime stage (`release/oci/Dockerfile`)

Runs `apt-get upgrade` before `apt-get install` in the runtime stage so that any Debian packages with released security patches are applied when the image is built.

This fixes CVE-2026-31789 (**CRITICAL**, heap buffer overflow in OpenSSL), which has a fix available in `3.5.5-1~deb13u2` but is not included in the base `python:3.14-slim-trixie` layer.

It also future-proofs image builds: subsequent Debian OS patches will be picked up automatically on rebuild.

## What is NOT fixed

The following Debian-level CVEs have **no fix available** from Debian yet — status is `affected` with no `Fixed Version` in Trivy. Rebuilding the image cannot address these; they require an upstream Debian patch:

- `libgnutls30t64`: CVE-2026-33845/33846/3833/42010/42011
- `libssh2-1t64`: CVE-2026-7598
- `ncurses`: CVE-2025-69720
- `libsystemd0`/`libudev1`: CVE-2026-29111
- `libnghttp2-14`: CVE-2026-27135
- `libcap2`: CVE-2026-4878

## Testing

The existing CI test suite covers the fastmcp API surface used by this project. The Dockerfile change is a drop-in addition with no behavioural impact beyond package versions.

After merging, tag `v0.1.2` to trigger the PyPI and OCI release workflows.