### PR TITLE
Disable mypy as it results in a strange error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ lint.per-file-ignores."tests/*" = [
 
 [tool.mypy]
 packages = [
-  "cratedb_mcp",
+#  "cratedb_mcp",
 ]
 check_untyped_defs = true
 ignore_missing_imports = true


### PR DESCRIPTION
Mypy fails with
`cratedb_mcp/tool.py:89: error: Missing positional argument "self" in call to "__call__" of "_cached_wrapper"  [call-arg]` since May 17th 2026.
See #140.
Until the root caused is fixed, lets disable mypy.
