### PR TITLE
Run httpbin in GHA or using docker

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up httpbin
-        uses: lfreleng-actions/setup-go-httpbin@v1
+        uses: lfreleng-actions/setup-go-httpbin@v0.1.5
         id: httpbin
 
       - name: Set up Python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,8 @@ jobs:
       - name: Set up httpbin
         uses: lfreleng-actions/setup-go-httpbin@v0.1.5
         id: httpbin
+        with:
+          skip-certificate: 'true'
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up httpbin
-        uses: lfreleng/setup-go-httpbin@v1
+        uses: lfreleng-actions/setup-go-httpbin@v1
         id: httpbin
 
       - name: Set up Python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,10 @@ jobs:
       - name: Acquire sources
         uses: actions/checkout@v6
 
+      - name: Set up httpbin
+        uses: lfreleng/setup-go-httpbin@v1
+        id: httpbin
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -14,6 +14,20 @@ uv pip install --upgrade --editable='.[develop,test]'
 
 ## Software tests
 
+Fist, you will need to prepare the httpbin service:
+
+```shell
+docker pull kennethreitz/httpbin
+docker run -p 8008:80 kennethreitz/httpbin
+export GO_HTTPBIN_URL=http://localhost:8008
+```
+
+Moreover, you will need to start a CrateDB server:
+
+```shell
+docker run --rm   --publish=4200:4200 --publish=5432:5432 --env=CRATE_HEAP_SIZE=2g   crate:latest -Cdiscovery.type=single-node
+```
+
 The project uses the [poethepoet] task runner, which provides convenience entry
 points for invoking linters and software tests. The top-level one-shot command
 will invoke both and is also used on CI/GHA.

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -64,7 +64,7 @@ def test_fragment_remote_success():
     """
     Verify fragments are loaded from HTTP URLs successfully.
     """
-    httpbin_url = os.environ.get('GO_HTTPBIN_URL')
+    httpbin_url = os.environ.get("GO_HTTPBIN_URL", "https://httpbin.org")
     instructions = InstructionsPrompt(instructions=httpbin_url + "/uuid")
     assert '"uuid"' in instructions.render()
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,4 +1,5 @@
 import io
+import os
 
 import pytest
 
@@ -63,7 +64,8 @@ def test_fragment_remote_success():
     """
     Verify fragments are loaded from HTTP URLs successfully.
     """
-    instructions = InstructionsPrompt(instructions="https://httpbin.org/uuid")
+    httpbin_url = os.environ.get('GO_HTTPBIN_URL')
+    instructions = InstructionsPrompt(instructions=httpbin_url + "/uuid")
     assert '"uuid"' in instructions.render()
 
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

The `httpbin` is flaky, and running it in docker container seems to be more reliable.

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes #145 
